### PR TITLE
V7.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://react-day-picker.js.org",
   "peerDependencies": {
-    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
+    "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@types/react": "^16.9.2",


### PR DESCRIPTION
v7.9.10 Upgrade
Enabled react ^18.0.0 as a peer dependency

Solution
Enabled higher versions of react without introducing new breaking changes in the library and on how to use the component